### PR TITLE
Add setting dialog, menu items and manage large files

### DIFF
--- a/gcoder.pro
+++ b/gcoder.pro
@@ -21,7 +21,7 @@ HEADERS     = \
     view.h \
     g2m/canonLine.hpp    g2m/canonMotionless.hpp  g2m/gplayer.hpp        g2m/linearMotion.hpp   g2m/nanotimer.hpp \
     g2m/canonMotion.hpp  g2m/g2m.hpp              g2m/helicalMotion.hpp  g2m/machineStatus.hpp  g2m/point.hpp \
-    lex_analyzer.hpp
+    lex_analyzer.hpp	settings_dlg.h
     
 
 SOURCES     = \
@@ -30,14 +30,14 @@ SOURCES     = \
     view.cpp \
     g2m/canonLine.cpp    g2m/canonMotionless.cpp  g2m/helicalMotion.cpp  g2m/machineStatus.cpp \
     g2m/canonMotion.cpp  g2m/g2m.cpp              g2m/linearMotion.cpp   g2m/nanotimer.cpp \
-    lex_analyzer.cpp
+    lex_analyzer.cpp     settings_dlg.cpp
 
 target.path = /usr/bin
 
 INSTALLS += target
 
 FORMS += \
-    mainwin.ui
+    mainwin.ui settings.ui
 
 link_pkgconfig {
 #  message("Using pkg-config "$$system(pkg-config --version)".")

--- a/mainwin.cpp
+++ b/mainwin.cpp
@@ -4,8 +4,13 @@
 #include <QPushButton>
 #include <QProcess>
 #include <QDesktopServices>
-
+#include <QFileDialog>
 #include <QDebug>
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -39,6 +44,7 @@ MainWindow::MainWindow(QWidget *parent) :
     connect( g2m, SIGNAL( signalError(QString) ),        ui->stderror, SLOT( setPlainText(QString) ) );
 
     connect(ui->gcode, SIGNAL(textChanged()), this, SLOT(changedGcode()));
+	connect(ui->gcode, SIGNAL(cursorPositionChanged()), this, SLOT(onChangedPosition()));
     connect(ui->command, SIGNAL(textChanged()), this, SLOT(changedCommand()));
 
     connect(ui->action_AutoZoom, SIGNAL(triggered()), this, SLOT(toggleAutoZoom()));
@@ -49,6 +55,13 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(ui->action_Issues, SIGNAL(triggered(bool)), this, SLOT(helpIssues()));
     connect(ui->action_Chat,   SIGNAL(triggered(bool)), this, SLOT(helpChat()));
 
+    // qt does not understand ~/ so path must be absolute or it will create ~/ on PWD
+    struct passwd *pw = getpwuid(getuid());
+    const char *homedir = pw->pw_dir;
+
+    home_dir = homedir;
+    openFile = "";
+
     loadSettings();
 
     QTimer::singleShot(0, this, SLOT(loadSettingsCommand()));
@@ -56,41 +69,54 @@ MainWindow::MainWindow(QWidget *parent) :
 
 MainWindow::~MainWindow()
 {
-//    delete ui;
-//    delete settings;
-//    delete g2m;
+
 }
 
 void MainWindow::toggleAutoZoom() {
     view->setAutoZoom(ui->action_AutoZoom->isChecked());
 }
 
-void MainWindow::changedCommand() {
+void MainWindow::changedCommand() 
+{
+QString str;
+
+    openFile = "";
+    bBigFile = bMoreBig = bFileMode = bFirstCallDone = false;
+    fileSize = filePos = 0;
+    connect(ui->gcode, SIGNAL(textChanged()), this, SLOT(changedGcode()));
+    disconnect(ui->gcode, SIGNAL(cursorPositionChanged()), this, SLOT(onChangedPosition()));
+    str = "GCoder :- ";
+    setWindowTitle(str);
     parseCommand();
 }
 
 void MainWindow::changedGcode() {
 
-    if (ui->gcode->toPlainText().isEmpty()) {
+if(bFileMode)
+    return;
+
+    if (ui->gcode->toPlainText().isEmpty()) 
+        {
         view->clear();
         ui->stderror->setPlainText("");
         return;
-    }
+        }
 
-    QFile f( "/tmp/gcode.ngc" );
-    if ( f.open( QIODevice::ReadWrite | QIODevice::Truncate | QIODevice::Text) ) {
+    QFile f(gcodefile);
+    if ( f.open( QIODevice::ReadWrite | QIODevice::Truncate | QIODevice::Text) ) 
+        {
         QTextStream out(&f);
         out << ui->gcode->toPlainText();
         f.close();
-    
+
         view->clear();
-    
-        emit setRS274("/usr/src/machinekit-main/bin/rs274");
-        emit setToolTable("/usr/src/machinekit-main/configs/sim/axis/sim_mm.tbl");
-        emit setGcodeFile("/tmp/gcode.ngc");
-        
+
+        emit setRS274(rs274);
+        emit setToolTable(tooltable);
+        emit setGcodeFile(gcodefile);
+
         emit interpret();
-    }
+        }
 }
 
 void MainWindow::appendCanonLine(g2m::canonLine* l) {
@@ -132,22 +158,36 @@ void MainWindow::parseCommand() {
     sh.close();
 }
 
-void MainWindow::loadSettings() {
-  settings->beginGroup("gui");
+////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  restoreGeometry(settings->value("geometry", saveGeometry() ).toByteArray());
-  restoreState(settings->value("state", saveState() ).toByteArray());
-  move(settings->value("pos", pos()).toPoint());
-  resize(settings->value("size", size()).toSize());
+void MainWindow::loadSettings() 
+{
 
-  if (settings->value("maximized", isMaximized() ).toBool()) {
-    showMaximized();
-  }
+    settings->beginGroup("gui");
 
-  view->setAutoZoom(settings->value("autoZoom", view->autoZoom()).toBool());
-  ui->action_AutoZoom->setChecked(settings->value("autoZoom", view->autoZoom()).toBool());
+    restoreGeometry(settings->value("geometry", saveGeometry() ).toByteArray());
+    restoreState(settings->value("state", saveState() ).toByteArray());
+    move(settings->value("pos", pos()).toPoint());
+    resize(settings->value("size", size()).toSize());
 
-  settings->endGroup();
+    if (settings->value("maximized", isMaximized() ).toBool()) 
+        showMaximized();
+
+    view->setAutoZoom(settings->value("autoZoom", view->autoZoom()).toBool());
+    ui->action_AutoZoom->setChecked(settings->value("autoZoom", view->autoZoom()).toBool());
+
+    rs274 = settings->value("rs274", "").toString();
+    tooltable = settings->value("tooltable", "").toString();
+    gcodefile = settings->value("gcodefile", "").toString();
+
+    settings->endGroup();
+        // if any of these paths is not known, cannot work properly, so insist
+    if(rs274.isEmpty() || tooltable.isEmpty() || gcodefile.isEmpty())
+        {
+        int ret = 1;
+        while(ret)
+            ret = onSettings();
+        }
 }
 
 void MainWindow::loadSettingsCommand() {
@@ -172,18 +212,252 @@ void MainWindow::saveSettings() {
   settings->setValue("command", ui->command->toPlainText());
 
   settings->setValue("autoZoom", ui->action_AutoZoom->isChecked());
+
+  settings->setValue("rs274", rs274);
+  settings->setValue("tooltable", tooltable);
+  settings->setValue("gcodefile", gcodefile);
   
   settings->endGroup();
 }
 
-void MainWindow::closeEvent(QCloseEvent * event) {
+/////////////////////////////////////////////////////////////////////////////////////////////////
+
+void MainWindow::closeEvent(QCloseEvent * event) 
+{
   qDebug() << "MainWindow::closeEvent";
   saveSettings();
 //      ui.viewer->close();
-  event->accept();
+
+    //  we are leaving it to QMainwindow to decide if to accept
+//  event->accept();
 
   QMainWindow::closeEvent(event);
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+void MainWindow::onOpenFile()
+{
+QString filename;
+QString path = home_dir + "/machinekit";
+
+    filename = QFileDialog::getOpenFileName(this, tr("Open GCode"), path, tr("GCode Files (*.ngc *.nc);; All files (*.*)"));
+    if(filename.length())
+        {
+        if(openInViewer(filename) == 0)
+            openInBrowser(filename);
+        }
+}
+
+int MainWindow::openInViewer(QString filename)
+{
+QFile fin(filename);
+QFile fout(gcodefile);
+QString str;
+
+    if (fin.open(QFile::ReadOnly | QFile::Text) &&  ( fout.open( QIODevice::ReadWrite | QIODevice::Truncate | QIODevice::Text) ) )
+        {
+        QTextStream ints(&fin);
+        QTextStream outts(&fout);
+        while(!ints.atEnd())
+            outts <<  ints.readLine() << "\n";
+        fin.close();
+        fout.close();
+
+        view->clear();
+        bFileMode = true;
+        disconnect(ui->gcode, SIGNAL(textChanged()), this, SLOT(changedGcode()));
+
+        emit setRS274(rs274);
+        emit setToolTable(tooltable);
+        emit setGcodeFile(gcodefile);
+
+        emit interpret();
+        return 0;
+        }
+    else 
+        return -1;
+}
+
+void MainWindow::openInBrowser(QString filename)
+{
+QFile file(filename);
+QString str;
+
+    if (file.open(QFile::ReadOnly | QFile::Text))
+        {
+        fileSize = file.size();
+        str = "Loading file " + filename;
+        ui->statusbar->showMessage(str, 5000);
+        ui->gcode->clear();        
+
+        QTextStream ts(&file);
+
+        while( (!ts.atEnd()) && (ts.pos() < CHUNK_SIZE) )
+            {
+            str = ts.readLine();
+            if(str.length())         
+                {
+                str = str + "\n";
+                ui->gcode->appendNewPlainText(str);
+                }
+            }
+
+        filePos = ts.pos();
+        if(file.size() > MAX_SIZE)
+        bBigFile = true;
+
+        if(fileSize >= filePos)
+            bMoreBig = true;
+        else
+            {
+            bBigFile = bMoreBig = false;
+            fileSize = filePos = 0;
+            }
+
+        file.close();  
+
+        str = "GCoder :- " +  filename;
+        setWindowTitle(str);
+
+        ui->gcode->highlightLine(1);
+
+        openFile = filename;
+        bFileMode = true;
+        if(bMoreBig)
+            connect(ui->gcode, SIGNAL(cursorPositionChanged()), this, SLOT(onChangedPosition()));
+        }
+    else
+        {
+        str = "Error loading file " + filename ;
+        ui->statusbar->showMessage(str, 5000);
+        }
+}
+
+void MainWindow::onChangedPosition()
+{
+    if(!bBigFile || !bMoreBig)
+        return;
+
+    if( (ui->gcode->textCursor().blockNumber() + 1) > ((ui->gcode->document()->blockCount()) - 100)  
+         && bFirstCallDone)
+        reOpenInBrowser();
+    else
+        bFirstCallDone = true;
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// called when further chunks of a large file are added to the text edit widget
+
+int MainWindow::reOpenInBrowser()
+{
+QString str, str2;
+QFile file(openFile);
+
+    if (file.open(QFile::ReadOnly | QFile::Text))
+        {
+        if(file.size() != fileSize)
+            {
+            str = "Error - file size has changed since last load - " + openFile ;
+            ui->statusbar->showMessage(str, 5000);
+            return -1;
+            }
+        QTextStream ts(&file);
+        ts.seek(filePos);
+
+        while( (!ts.atEnd()) && (ts.pos() < (filePos + ADD_SIZE) ) )
+            {
+            str = ts.readLine();
+            if(str.length())
+                {
+                str = str + "\n";
+                ui->gcode->appendNewPlainText(str);
+                }
+            }
+
+        filePos = ts.pos();
+        if(fileSize > filePos)
+            bMoreBig = true;
+        else
+            {
+            bBigFile = bMoreBig = false;
+            fileSize = filePos = 0;
+            disconnect(ui->gcode, SIGNAL(cursorPositionChanged()), this, SLOT(onChangedPosition()));
+            }
+        file.close();  
+        return 0;
+        }
+    else
+        {
+        str = "Error reOpening file " + openFile;
+        ui->statusbar->showMessage(str, 10000);
+        return -1;
+        }
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void MainWindow::onSaveAs()
+{
+    QString fileName = QFileDialog::getSaveFileName(this, tr("Save G Code (As)"), openFile, tr("GCode Files (*.ngc *.nc);; All files (*.*)"));
+    saveInBrowser(fileName);
+    // bModified = false;	
+}
+
+
+
+int  MainWindow::saveInBrowser(QString& filename)
+{
+QFile file(filename);
+QString str;
+
+    if (file.open(QIODevice::ReadWrite | QIODevice::Text))
+        {
+        QTextStream out(&file);
+        out << ui->gcode->toPlainText();
+        file.close();
+
+        //ui->gcode->setReadOnly(true);
+        str = "GCoder:- " +  filename;
+        setWindowTitle(str);
+        return 0;
+        }
+    else
+        {
+        str = "Error saving file " + filename ;
+        ui->statusbar->showMessage(str, 5000);
+        return -1;
+        }
+}
+/////////////////////////////////////////////////////////////////////////////////////////////////////
+
+int MainWindow::onSettings()
+{
+
+    SettingsDialog *dlg = new SettingsDialog(this, home_dir);
+
+    dlg->setValues(rs274, tooltable, gcodefile);
+
+    dlg->exec();
+
+    if(dlg->result())
+        {
+        rs274 = dlg->rs274;
+        tooltable = dlg->tooltable;
+        gcodefile = dlg->gcodefile;
+        }
+
+    if(rs274.isEmpty() || tooltable.isEmpty() || gcodefile.isEmpty())	
+        return 1;
+    else
+        return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void MainWindow::helpDonate() {
     QDesktopServices::openUrl(QUrl("https://koppi.github.com/paypal"));

--- a/mainwin.h
+++ b/mainwin.h
@@ -8,10 +8,18 @@
 #include "QGCodeEditor.h"
 #include "view.h"
 #include "g2m.hpp"
+#include "settings_dlg.h"
 
 namespace Ui {
 class MainWindow;
 }
+
+// max file size of 25KB
+#define MAX_SIZE 25000
+// render initial 3K chunk
+#define CHUNK_SIZE 3000
+// add in 1K bits dynamically
+#define ADD_SIZE 1000
 
 class MainWindow : public QMainWindow
 {
@@ -38,6 +46,11 @@ public slots:
     void changedGcode();
     void changedCommand();
 
+    void onOpenFile();
+    void onSaveAs();
+    int onSettings();
+    void onChangedPosition();
+
     void appendCanonLine(g2m::canonLine*);
 
     void toggleAutoZoom();
@@ -51,9 +64,22 @@ protected:
     void saveSettings();
 
 private:
+    int openInViewer(QString filename);
+    void openInBrowser(QString filename);
+    int reOpenInBrowser();
+    int saveInBrowser(QString& filename);
+
     void closeEvent(QCloseEvent *) Q_DECL_OVERRIDE;
 
 private:
+    QString home_dir, openFile;
+    int fileSize, filePos;
+    bool bMoreBig, bBigFile, bFileMode, bFirstCallDone;
+
+    QString rs274;
+    QString tooltable;
+    QString gcodefile;
+
     Ui::MainWindow *ui;
 
     View *view;

--- a/mainwin.ui
+++ b/mainwin.ui
@@ -51,6 +51,11 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <addaction name="action_Open"/>
+    <addaction name="action_Save_As"/>
+    <addaction name="separator"/>
+    <addaction name="action_Settings"/>
+    <addaction name="separator"/>
     <addaction name="action_Quit"/>
    </widget>
    <widget class="QMenu" name="menu_View">
@@ -172,7 +177,6 @@
    <attribute name="toolBarBreak">
     <bool>false</bool>
    </attribute>
-   <addaction name="action_Quit"/>
    <addaction name="separator"/>
    <addaction name="action_showFullScreen"/>
    <addaction name="action_showNormal"/>
@@ -278,6 +282,33 @@
     <string>&amp;Chat</string>
    </property>
   </action>
+  <action name="action_Open">
+   <property name="text">
+    <string>File Open</string>
+   </property>
+   <property name="toolTip">
+    <string>Open File</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
+  </action>
+  <action name="action_Settings">
+   <property name="text">
+    <string>Set local paths</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+T</string>
+   </property>
+  </action>
+  <action name="action_Save_As">
+   <property name="text">
+    <string>File Save As</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+A</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -336,5 +367,58 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>action_Open</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>onOpenFile()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>285</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>action_Settings</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>onSettings()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>285</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>action_Save_As</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>onSaveAs()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>285</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
+ <slots>
+  <slot>onOpenFile()</slot>
+  <slot>onSettings()</slot>
+  <slot>onSaveAs()</slot>
+ </slots>
 </ui>

--- a/settings.ui
+++ b/settings.ui
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Settings</class>
+ <widget class="QDialog" name="Settings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>472</width>
+    <height>262</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>GCoder path settings</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_4">
+   <item row="0" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Path to rs274 interpreter:-</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLineEdit" name="le_path1">
+        <property name="toolTip">
+         <string>rs274 will be in the /bin dir
+of your machinekit installation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="pb_browse1">
+        <property name="text">
+         <string>Browse</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Path to tool table</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLineEdit" name="le_path2">
+        <property name="toolTip">
+         <string>A xxx.tbl file will be in your
+machinekit machine config dir</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="pb_browse2">
+        <property name="text">
+         <string>Browse</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Temporary GCode file to use</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLineEdit" name="le_path3">
+        <property name="toolTip">
+         <string>Only change this if you wish to start with a specific file
+Beware it could be overwritten.</string>
+        </property>
+        <property name="text">
+         <string>/tmp/gcode.ngc</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="pb_browse3">
+        <property name="text">
+         <string>Browse</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>269</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="1">
+    <widget class="QPushButton" name="pushButton">
+     <property name="text">
+      <string>Cancel</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QPushButton" name="pushButton_2">
+     <property name="text">
+      <string>OK</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>pb_browse1</sender>
+   <signal>clicked()</signal>
+   <receiver>Settings</receiver>
+   <slot>onFileBrowse1()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>362</x>
+     <y>50</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>389</x>
+     <y>80</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pb_browse2</sender>
+   <signal>clicked()</signal>
+   <receiver>Settings</receiver>
+   <slot>onFileBrowse2()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>357</x>
+     <y>130</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>382</x>
+     <y>167</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pb_browse3</sender>
+   <signal>clicked()</signal>
+   <receiver>Settings</receiver>
+   <slot>onFileBrowse3()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>352</x>
+     <y>210</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>389</x>
+     <y>237</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton_2</sender>
+   <signal>clicked()</signal>
+   <receiver>Settings</receiver>
+   <slot>onAccept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>345</x>
+     <y>263</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>327</x>
+     <y>280</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pushButton</sender>
+   <signal>clicked()</signal>
+   <receiver>Settings</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>265</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>137</x>
+     <y>267</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>onFileBrowse1()</slot>
+  <slot>onFileBrowse2()</slot>
+  <slot>onFileBrowse3()</slot>
+  <slot>onAccept()</slot>
+ </slots>
+</ui>

--- a/settings_dlg.cpp
+++ b/settings_dlg.cpp
@@ -1,0 +1,73 @@
+#include "settings_dlg.h"
+#include <QDir>
+
+SettingsDialog::SettingsDialog(QWidget *parent, QString& homedir)
+:QDialog(parent)
+{
+QString str;
+
+    // build the dialog from ui
+    setupUi(this);
+    home_dir = homedir;
+
+}
+
+void SettingsDialog::setValues(QString& rs, QString& tbl, QString& gcode)
+{
+    le_path1->setText(rs274 = rs);
+    le_path2->setText(tooltable = tbl);
+    le_path3->setText(gcodefile = gcode);
+}
+
+void SettingsDialog::onFileBrowse(int buttonNumber)
+{
+QString pathStr;
+QString filename;
+QDir dir;
+
+    if( buttonNumber == 1)
+        {
+        if(rs274.isEmpty())
+            pathStr = "/usr/bin";
+        else
+            pathStr = dir.absoluteFilePath(rs274);
+        }
+    else if(buttonNumber == 2)
+        {
+        if(tooltable.isEmpty())
+            pathStr = home_dir + "/machinekit/configs";
+        else
+            pathStr = dir.absoluteFilePath(tooltable);
+        }
+    else
+        {
+        if(gcodefile.isEmpty())
+            pathStr = "/tmp";
+        else
+            pathStr = dir.absoluteFilePath(gcodefile);
+        }
+
+    filename = QFileDialog::getOpenFileName(this, tr("Settings Paths"), pathStr, tr("All files (*)"));
+    if(filename.length())
+        {
+        if( buttonNumber == 1)
+            le_path1->setText(filename);
+        else if(buttonNumber == 2)
+            le_path2->setText(filename);
+        else
+            le_path3->setText(filename);
+        }
+}
+
+void SettingsDialog::onAccept()
+{
+    rs274 = le_path1->text();
+    tooltable = le_path2->text();
+    gcodefile = le_path3->text();
+
+    QDialog::accept();
+}
+
+
+
+

--- a/settings_dlg.h
+++ b/settings_dlg.h
@@ -1,0 +1,39 @@
+
+#ifndef SETTINGS_DLG_H
+#define SETTINGS_DLG_H
+
+#include <QtGui>
+#include <QSettings>
+#include <QCoreApplication>
+#include <QFileDialog>
+#include <QDebug>
+
+#include "ui_settings.h"
+
+
+class SettingsDialog  : public QDialog , private Ui_Settings
+{
+    Q_OBJECT
+public:
+
+    SettingsDialog(QWidget* parent, QString& homedir);
+
+    void setValues(QString& rs, QString& tbl, QString& gcode);
+    QString rs274;
+    QString tooltable;
+    QString gcodefile;
+
+private:
+    void onFileBrowse(int buttonNumber);
+    QString home_dir;
+
+private slots:
+    virtual void onFileBrowse1() {onFileBrowse(1);}
+    virtual void onFileBrowse2() {onFileBrowse(2);}
+    virtual void onFileBrowse3() {onFileBrowse(3);}
+
+    virtual void onAccept();
+};
+
+
+#endif


### PR DESCRIPTION
settings_dlg gathers paths for rs274, tooltable and temporary gcode file.
If any of these are not set, pops up at launch and sets them
in variables within the class.

File Open and File Save As added

Large file management by setting limits to initial amount of a file read into
QGCodeEditor widget, with further blocks read in if cursor position nears
the end of the current amount in the editor.

This reduces the time to load a 10,000 line file, from 30 seconds just for the editor
to +/- 5secs for both editor and GLViewer combined

This is an interim measure.  Full solution will be via changes to editor itself
to do this irrespective of the input source.

Signed-off-by: Mick arceye@mgware.co.uk
