### PR TITLE
Make large file loads generic GCodeEditor function & remove from here

### DIFF
--- a/mainwin.h
+++ b/mainwin.h
@@ -14,13 +14,6 @@ namespace Ui {
 class MainWindow;
 }
 
-// max file size of 25KB
-#define MAX_SIZE 25000
-// render initial 3K chunk
-#define CHUNK_SIZE 3000
-// add in 1K bits dynamically
-#define ADD_SIZE 1000
-
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -41,40 +34,38 @@ signals:
 public slots:
     // load the last command string from the settings
     // used during startup
-    void loadSettingsCommand();
+    virtual void loadSettingsCommand();
 
-    void changedGcode();
-    void changedCommand();
+    virtual void changedGcode();
+    virtual void changedCommand();
 
-    void onOpenFile();
-    void onSaveAs();
-    int onSettings();
-    void onChangedPosition();
+    virtual void onOpenFile();
+    virtual void onSaveAs();
+    virtual int onSettings();
 
-    void appendCanonLine(g2m::canonLine*);
+    virtual void appendCanonLine(g2m::canonLine*);
 
-    void toggleAutoZoom();
-
-    void helpDonate();
-    void helpIssues();
-    void helpChat();
+    virtual void toggleAutoZoom();
+    virtual void showFullScreen();
+    
+    virtual void helpDonate();
+    virtual void helpIssues();
+    virtual void helpChat();
 
 protected:
     void loadSettings();
     void saveSettings();
 
-private:
+private:  // functions
     int openInViewer(QString filename);
     void openInBrowser(QString filename);
-    int reOpenInBrowser();
     int saveInBrowser(QString& filename);
 
     void closeEvent(QCloseEvent *) Q_DECL_OVERRIDE;
 
-private:
+private: // data
     QString home_dir, openFile;
-    int fileSize, filePos;
-    bool bMoreBig, bBigFile, bFileMode, bFirstCallDone;
+    bool bFileMode;
 
     QString rs274;
     QString tooltable;

--- a/mainwin.ui
+++ b/mainwin.ui
@@ -62,7 +62,6 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
-    <addaction name="action_showNormal"/>
     <addaction name="action_showFullScreen"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
@@ -179,7 +178,6 @@
    </attribute>
    <addaction name="separator"/>
    <addaction name="action_showFullScreen"/>
-   <addaction name="action_showNormal"/>
    <addaction name="separator"/>
    <addaction name="action_AutoZoom"/>
   </widget>
@@ -228,6 +226,9 @@
    </property>
   </action>
   <action name="action_showFullScreen">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>&amp;Fullscreen</string>
    </property>
@@ -340,22 +341,6 @@
    <signal>triggered()</signal>
    <receiver>MainWindow</receiver>
    <slot>showFullScreen()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>399</x>
-     <y>299</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>action_showNormal</sender>
-   <signal>triggered()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>showNormal()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>

--- a/settings_dlg.cpp
+++ b/settings_dlg.cpp
@@ -35,7 +35,7 @@ QDir dir;
     else if(buttonNumber == 2)
         {
         if(tooltable.isEmpty())
-            pathStr = home_dir + "/machinekit/configs";
+            pathStr = home_dir + "machinekit/configs";
         else
             pathStr = dir.absoluteFilePath(tooltable);
         }


### PR DESCRIPTION
Add FileOpen and FileSaveAs

Split calls to load file between view and editor

Platform independent home folder detection

Fullscreen action toggles in single button

Settings dialog Browse path defaults to existing one if set.

Signed-off-by: Mick arceye@mgware.co.uk
